### PR TITLE
Make sure hideMenuViewController method can be used in swift

### DIFF
--- a/RESideMenu/RESideMenu.h
+++ b/RESideMenu/RESideMenu.h
@@ -79,7 +79,7 @@
             rightMenuViewController:(UIViewController *)rightMenuViewController;
 - (void)presentLeftMenuViewController;
 - (void)presentRightMenuViewController;
-- (void)hideMenuViewController;
+- (void)hideMenuViewController NS_SWIFT_NAME(hideSideMenuViewController());
 - (void)setContentViewController:(UIViewController *)contentViewController animated:(BOOL)animated;
 
 @end


### PR DESCRIPTION
Xcode automatically rename hideMenuViewController to hideViewController when preparing swift interface, which is wrong.
Force renaming it to hideSideMenuViewController for swift using NS_SWIFT_NAME.